### PR TITLE
Avoid function call by using an or condition

### DIFF
--- a/zeta/Interpreter.java
+++ b/zeta/Interpreter.java
@@ -354,7 +354,7 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void>{
     }
     private boolean isEqual(Object left, Object right) {
         if(left == null && right == null) return true;
-        if(left == null) return false;
+        if(left == null || right == null) return false;
         return left.equals(right);
     }
     private boolean isTruthy(Object object) {


### PR DESCRIPTION
It avoids one function call by adding right to the or condition.

There is a condition that checks if right==left==null
Therefore after not matching that condition, it means that if either right or left is null it will mean that the other is not, which means they are different.